### PR TITLE
feat(auth): Implement role-based post-login redirection

### DIFF
--- a/app/Http/Controllers/Auth/AuthenticatedSessionController.php
+++ b/app/Http/Controllers/Auth/AuthenticatedSessionController.php
@@ -28,6 +28,17 @@ class AuthenticatedSessionController extends Controller
 
         $request->session()->regenerate();
 
+        $user = Auth::user();
+
+        if ($user->level === 'admin') {
+            return redirect('/admin');
+        } elseif ($user->level === 'petugas') {
+            return redirect('/petugas'); // Assuming a 'petugas' panel path
+        } elseif ($user->level === 'anggota') {
+            return redirect(route('dashboard', absolute: false)); // Redirect 'anggota' to the general dashboard
+        }
+
+        // Default redirection if no specific role match
         return redirect()->intended(route('dashboard', absolute: false));
     }
 


### PR DESCRIPTION
This commit introduces logic to redirect users to specific panels or dashboards based on their assigned 'level' (role) after a successful login.

- Admin users are redirected to `/admin`.
- Petugas users are redirected to `/petugas` (assuming a dedicated panel).
- Anggota users are redirected to the general dashboard.

This resolves the issue where users were not automatically redirected to their appropriate panel or dashboard after login, and also fixes the 403 Unauthorized error encountered by non-admin users when attempting to access the admin panel.